### PR TITLE
After closing the dialog, `more info` button will be focused.

### DIFF
--- a/src/preferencesControl.ts
+++ b/src/preferencesControl.ts
@@ -147,6 +147,12 @@ export class PreferencesControl {
     public hidePreferencesDialog(): void {
         let cookieModal = document.getElementsByClassName(styles.cookieModal)[0];
         this.containerElement.removeChild(cookieModal);
+
+        let cookieInfo = document.getElementsByClassName(styles.bannerButton)[1];
+        if (cookieInfo) {
+            (<HTMLElement> cookieInfo).focus();
+        }
+
         this.onPreferencesClosed();
     }
 


### PR DESCRIPTION
1. After closing the dialog, `more info` button will be focused.
2. The banner and dialog are not in DOM when `Save changes` button is clicked. Therefore, we will not handle this scenario.