### PR TITLE
Fix the bug that pressing tab key after reset all button focus order is not in logical order

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ var cc = new ConsentControl(
 
 + `createTheme(name: string, theme: ITheme)` can be used to create the new theme. `name` is the name of this new theme, which can be used by `applyTheme(themeName: string)`. `theme` is the new theme object.
     
-    `ConsentControl` consists of three built in themes, `light`, `dark`, and `high-contrast`. `dark` and `high-contrast` themes are from [Microsoft Docs](docs.microsoft.com).
+    `ConsentControl` consists of three built in themes, `light`, `dark`, and `high-contrast`. `dark` and `high-contrast` themes are from [Microsoft Docs](https://docs.microsoft.com/en-us/).
 
 + You can apply the theme manually by using `applyTheme(themeName: string)`. `themeName` is the name of the theme which you want to apply.
 
@@ -188,6 +188,8 @@ var cc = new ConsentControl(
     // Apply the "medium" theme
     cc.applyTheme("medium");
     ```
+
+    If the name of theme is not in the themes collections, it will throw an error. `new Error("Theme not found error")`
 
 + `setContainerElement(containerElementOrId: string | HTMLElement)` can be used to set the container element for the banner and preferences dialog. 
 
@@ -293,6 +295,7 @@ interface IThemes {
 }
 
 interface ITheme {
+    // All required properties
     "close-button-color": string;
     "secondary-button-disabled-opacity": string;
     "secondary-button-hover-shadow": string;
@@ -307,6 +310,8 @@ interface ITheme {
     "secondary-button-color": string;
     "secondary-button-disabled-color": string;
     "secondary-button-border": string;
+
+    // All optional properties
     "background-color-between-page-and-dialog"?: string;
     "dialog-border-color"?: string;
     "hyperlink-font-color"?: string;

--- a/dist/index.html
+++ b/dist/index.html
@@ -10,6 +10,10 @@
     <div id="app"></div>
     <h1>aaabcdef</h1>
     <script src="consent-banner.js"></script>
+    <script type="text/javascript">
+        let cc = new ConsentControl.ConsentControl("app", "en");
+        cc.showBanner({});
+    </script>
 </body>
 
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "consent-banner",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "The library which will generate a banner at the specified position for asking the cookie preferences.",
   "main": "dist/consent-banner.js",
   "types": "dist/consent-banner.d.ts",

--- a/src/preferencesControl.ts
+++ b/src/preferencesControl.ts
@@ -37,8 +37,8 @@ export class PreferencesControl {
     public createPreferencesDialog(): void {
         let cookieModalInnerHtml = `
         <div role="presentation" tabindex="-1"></div>
-        <div role="dialog" aria-modal="true" aria-label="${ HtmlTools.escapeHtml(this.textResources.preferencesDialogTitle) }" class="${ styles.modalContainer }" tabindex="-1">
-            <button aria-label="${ HtmlTools.escapeHtml(this.textResources.preferencesDialogCloseLabel) }" class="${ styles.closeModalIcon }" tabindex="0">&#x2715;</button>
+        <div role="dialog" aria-modal="true" aria-label="${ HtmlTools.escapeHtml(this.textResources.preferencesDialogTitle) }" class="${ styles.modalContainer }" tabindex="0">
+            <button aria-label="${ HtmlTools.escapeHtml(this.textResources.preferencesDialogCloseLabel) }" class="${ styles.closeModalIcon }">&#x2715;</button>
             <div role="document" class="${ styles.modalBody }">
                 <div>
                     <h2 class="${styles.modalTitle} ${ styles.textColorTheme }">${ HtmlTools.escapeHtml(this.textResources.preferencesDialogTitle) }</h2>
@@ -215,6 +215,14 @@ export class PreferencesControl {
 
             // Reset UI
             this.setRadioBtnState();
+        });
+    
+        modalButtonReset?.addEventListener('keydown', (event) => {
+            if (event.keyCode == 9 && !event.shiftKey) {
+                event.preventDefault();
+                let dialog = <HTMLElement> document.getElementsByClassName(styles.modalContainer)[0];
+                dialog.focus();
+            }
         });
     }
     

--- a/src/preferencesControl.ts
+++ b/src/preferencesControl.ts
@@ -162,45 +162,54 @@ export class PreferencesControl {
      * 2. Click any "accept/reject" button, "Save changes" and "Reset all" button will be enabled
      * 3. Click any "accept/reject" button, cookieCategoriesPreferences will be set
      * 4. Click "Reset all" button, cookieCategoriesPreferences will be reset
+     * 5. When "X" button is focused, press Tab + Shift keys. Last element will be focused.
+     * 6. When last element is focused, press Tab key. "X" button will be focused.
      */
     private addPreferencesButtonsEvent(): void {
         let closeModalIcon: HTMLElement = <HTMLElement> document.getElementsByClassName(styles.closeModalIcon)[0];
 
-        let cookieItemRadioBtn: Element[] = [].slice.call(document.getElementsByClassName(styles.cookieItemRadioBtn));
         let modalButtonSave: HTMLInputElement = <HTMLInputElement> document.getElementsByClassName(styles.modalButtonSave)[0];
         let modalButtonReset: HTMLInputElement = <HTMLInputElement> document.getElementsByClassName(styles.modalButtonReset)[0];
 
+        let acceptRejectButtons: Element[] = [].slice.call(document.getElementsByClassName(styles.cookieItemRadioBtn));
         let lastAcceptRadioBtn: HTMLElement | null = null;
         let lastRejectRadioBtn: HTMLElement | null = null;
-        if (cookieItemRadioBtn && cookieItemRadioBtn.length) {
-            lastAcceptRadioBtn = <HTMLElement> cookieItemRadioBtn[cookieItemRadioBtn.length - 1];
-            lastRejectRadioBtn = <HTMLElement> cookieItemRadioBtn[cookieItemRadioBtn.length - 2];
+        if (acceptRejectButtons.length) {
+            lastAcceptRadioBtn = <HTMLElement> acceptRejectButtons[acceptRejectButtons.length - 2];
+            lastRejectRadioBtn = <HTMLElement> acceptRejectButtons[acceptRejectButtons.length - 1];
         }
 
         let lastElementTab = function(event: KeyboardEvent): void {
-            if (event.keyCode == 9 && !event.shiftKey) {
+            if (event.key == 'Tab' && !event.shiftKey) {
                 event.preventDefault();
                 closeModalIcon.focus();
             }
         };
         let firstElementShiftTab = function(event: KeyboardEvent): void {
-            if (event.keyCode == 9 && event.shiftKey) {
+            if (event.key == 'Tab' && event.shiftKey) {
                 event.preventDefault();
-                lastAcceptRadioBtn?.focus();
+                lastRejectRadioBtn?.focus();
             }
         };
 
-        if (modalButtonReset && modalButtonSave && modalButtonReset.disabled && modalButtonSave.disabled) {
-            if (cookieItemRadioBtn && cookieItemRadioBtn.length) {
+        modalButtonReset?.addEventListener('keydown', (event) => {
+            if (event.key == 'Tab' && !event.shiftKey) {
+                event.preventDefault();
+                closeModalIcon.focus();
+            }
+        });
+
+        if (modalButtonReset.disabled && modalButtonSave.disabled) {
+            if (acceptRejectButtons.length) {
                 lastAcceptRadioBtn?.addEventListener('keydown', lastElementTab);
                 lastRejectRadioBtn?.addEventListener('keydown', lastElementTab);
 
                 closeModalIcon?.addEventListener('keydown', firstElementShiftTab);
             }
         }
-        else if (modalButtonReset && !modalButtonReset.disabled) {
+        else {
             closeModalIcon?.addEventListener('keydown', (event) => {
-                if (event.keyCode == 9 && event.shiftKey) {
+                if (event.key == 'Tab' && event.shiftKey) {
                     event.preventDefault();
                     modalButtonReset.focus();
                 }
@@ -209,8 +218,8 @@ export class PreferencesControl {
 
         closeModalIcon?.addEventListener('click', () => this.hidePreferencesDialog());
         
-        if (cookieItemRadioBtn && cookieItemRadioBtn.length) {
-            for (let radio of cookieItemRadioBtn) {
+        if (acceptRejectButtons.length) {
+            for (let radio of acceptRejectButtons) {
                 radio.addEventListener('click', () => {
                     let categId = radio.getAttribute('name');
                     if (categId) {
@@ -225,13 +234,16 @@ export class PreferencesControl {
                             this.cookieCategoriesPreferences[categId] = false;
                         }
     
-                        // Enable "Save changes" and "Reset all" buttons
+                        // Enable "Save changes" button
                         if (oldCategValue !== this.cookieCategoriesPreferences[categId]) {
-                            if (modalButtonSave) {
+                            if (modalButtonSave.disabled) {
                                 modalButtonSave.disabled = false;
                             }
                         }
-                        if (modalButtonReset) {
+
+                        // Enable "Reset all" button
+                        // Update event listener function in "X" and remove event listener in last accept/reject radio buttons
+                        if (modalButtonReset.disabled) {
                             modalButtonReset.disabled = false;
 
                             lastAcceptRadioBtn?.removeEventListener('keydown', lastElementTab);
@@ -239,7 +251,7 @@ export class PreferencesControl {
                             
                             closeModalIcon?.removeEventListener('keydown', firstElementShiftTab);
                             closeModalIcon?.addEventListener('keydown', (event) => {
-                                if (event.keyCode == 9 && event.shiftKey) {
+                                if (event.key == 'Tab' && event.shiftKey) {
                                     event.preventDefault();
                                     modalButtonReset.focus();
                                 }
@@ -263,13 +275,6 @@ export class PreferencesControl {
 
             // Reset UI
             this.setRadioBtnState();
-        });
-    
-        modalButtonReset?.addEventListener('keydown', (event) => {
-            if (event.keyCode == 9 && !event.shiftKey) {
-                event.preventDefault();
-                closeModalIcon.focus();
-            }
         });
     }
     

--- a/src/preferencesControl.ts
+++ b/src/preferencesControl.ts
@@ -171,41 +171,35 @@ export class PreferencesControl {
         let modalButtonSave: HTMLInputElement = <HTMLInputElement> document.getElementsByClassName(styles.modalButtonSave)[0];
         let modalButtonReset: HTMLInputElement = <HTMLInputElement> document.getElementsByClassName(styles.modalButtonReset)[0];
 
-        this.handleAccessibility();
+        this.controlNextActiveElement();
 
         closeModalIcon?.addEventListener('click', () => this.hidePreferencesDialog());
 
-        if (acceptRejectButtons.length) {
-            for (let radio of acceptRejectButtons) {
-                radio.addEventListener('click', () => {
-                    let categId = radio.getAttribute('name');
-                    if (categId) {
-                        let oldCategValue = this.cookieCategoriesPreferences[categId];
+        for (let radio of acceptRejectButtons) {
+            radio.addEventListener('click', () => {
+                let categId = radio.getAttribute('name');
+                if (categId) {
+                    let oldCategValue = this.cookieCategoriesPreferences[categId];
 
-                        // Change cookieCategoriesPreferences
-                        let categValue = radio.getAttribute('value');
-                        if (categValue === 'accept') {
-                            this.cookieCategoriesPreferences[categId] = true;
-                        }
-                        else {   // categValue === 'reject'
-                            this.cookieCategoriesPreferences[categId] = false;
-                        }
-
-                        // Enable "Save changes" button
-                        if (oldCategValue !== this.cookieCategoriesPreferences[categId]) {
-                            if (modalButtonSave.disabled) {
-                                modalButtonSave.disabled = false;
-                            }
-                        }
+                    // Change cookieCategoriesPreferences
+                    let categValue = radio.getAttribute('value');
+                    if (categValue === 'accept') {
+                        this.cookieCategoriesPreferences[categId] = true;
                     }
-                });
-            }
+                    else {   // categValue === 'reject'
+                        this.cookieCategoriesPreferences[categId] = false;
+                    }
+
+                    // Enable "Save changes" button
+                    if (oldCategValue !== this.cookieCategoriesPreferences[categId]) {
+                        modalButtonSave.disabled = false;
+                    }
+                }
+            });
         }
 
         modalButtonReset?.addEventListener('click', () => {
-            if (modalButtonSave.disabled) {
-                modalButtonSave.disabled = false;
-            }
+            modalButtonSave.disabled = false;
 
             for (let cookieCategory of this.cookieCategories) {
                 if (!cookieCategory.isUnswitchable) {
@@ -222,7 +216,7 @@ export class PreferencesControl {
      * 1. When "X" button is focused, press Tab + Shift keys. Last element will be focused.
      * 2. When last element is focused, press Tab key. "X" button will be focused.
      */
-    private handleAccessibility(): void {
+    private controlNextActiveElement(): void {
         let closeModalIcon: HTMLElement = <HTMLElement> document.getElementsByClassName(styles.closeModalIcon)[0];
         let modalButtonSave: HTMLInputElement = <HTMLInputElement> document.getElementsByClassName(styles.modalButtonSave)[0];
         let modalButtonReset: HTMLInputElement = <HTMLInputElement> document.getElementsByClassName(styles.modalButtonReset)[0];
@@ -248,8 +242,14 @@ export class PreferencesControl {
                 lastRejectRadioBtn?.focus();
             }
         };
+        let closeIconShiftTab2Reset = function(event: KeyboardEvent): void {
+            if (event.key == 'Tab' && event.shiftKey) {
+                event.preventDefault();
+                modalButtonReset.focus();
+            }
+        }
 
-        modalButtonReset?.addEventListener('keydown', (event) => {
+        modalButtonReset.addEventListener('keydown', (event) => {
             if (event.key == 'Tab' && !event.shiftKey) {
                 event.preventDefault();
                 closeModalIcon.focus();
@@ -261,39 +261,27 @@ export class PreferencesControl {
                 lastAcceptRadioBtn?.addEventListener('keydown', lastElementTab);
                 lastRejectRadioBtn?.addEventListener('keydown', lastElementTab);
 
-                closeModalIcon?.addEventListener('keydown', firstElementShiftTab);
+                closeModalIcon.addEventListener('keydown', firstElementShiftTab);
             }
         }
         else {
-            closeModalIcon?.addEventListener('keydown', (event) => {
-                if (event.key == 'Tab' && event.shiftKey) {
-                    event.preventDefault();
-                    modalButtonReset.focus();
-                }
-            });
+            closeModalIcon.addEventListener('keydown', closeIconShiftTab2Reset);
         }
 
-        if (acceptRejectButtons.length) {
-            for (let radio of acceptRejectButtons) {
-                radio.addEventListener('click', () => {
-                    // Enable "Reset all" button
-                    // Update event listener function in "X" and remove event listener in last accept/reject radio buttons
-                    if (modalButtonReset.disabled) {
-                        modalButtonReset.disabled = false;
+        for (let radio of acceptRejectButtons) {
+            radio.addEventListener('click', () => {
+                // Enable "Reset all" button
+                // Update event listener function in "X" and remove event listener in last accept/reject radio buttons
+                if (modalButtonReset.disabled) {
+                    modalButtonReset.disabled = false;
 
-                        lastAcceptRadioBtn?.removeEventListener('keydown', lastElementTab);
-                        lastRejectRadioBtn?.removeEventListener('keydown', lastElementTab);
-                        
-                        closeModalIcon?.removeEventListener('keydown', firstElementShiftTab);
-                        closeModalIcon?.addEventListener('keydown', (event) => {
-                            if (event.key == 'Tab' && event.shiftKey) {
-                                event.preventDefault();
-                                modalButtonReset.focus();
-                            }
-                        });
-                    }
-                });
-            }
+                    lastAcceptRadioBtn?.removeEventListener('keydown', lastElementTab);
+                    lastRejectRadioBtn?.removeEventListener('keydown', lastElementTab);
+                    
+                    closeModalIcon.removeEventListener('keydown', firstElementShiftTab);
+                    closeModalIcon.addEventListener('keydown', closeIconShiftTab2Reset);
+                }
+            });
         }
     }
     

--- a/src/preferencesControl.ts
+++ b/src/preferencesControl.ts
@@ -217,11 +217,22 @@ export class PreferencesControl {
             this.setRadioBtnState();
         });
     
+        let dialog = <HTMLElement> document.getElementsByClassName(styles.modalContainer)[0];
         modalButtonReset?.addEventListener('keydown', (event) => {
             if (event.keyCode == 9 && !event.shiftKey) {
                 event.preventDefault();
-                let dialog = <HTMLElement> document.getElementsByClassName(styles.modalContainer)[0];
                 dialog.focus();
+            }
+        });
+
+        dialog?.addEventListener('keydown', (event) => {
+            if (event.target !== event.currentTarget) {
+                return;
+            }
+
+            if (event.keyCode == 9 && event.shiftKey) {
+                event.preventDefault();
+                modalButtonReset.focus();
             }
         });
     }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -264,6 +264,7 @@ li.cookieListItem {
 .cookieItemRadioBtnCtrl {
   display: inline-block;
   position: relative;
+  left: 2px;
   margin : {
     bottom: 16px;
   }
@@ -355,7 +356,6 @@ input[type="radio"].cookieItemRadioBtn {
   width: 20px;
   height: 20px;
   border-radius: 50%;
-  outline: none;
 
   cursor: pointer;
   box-sizing: border-box;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -284,6 +284,10 @@ li.cookieListItem {
     background-color: $dialog-background-color;
   }
 
+  &:focus + span::before {
+    outline: 2px solid $radio-button-hover-background-color;
+  }
+
   &:not(:disabled) + span {
     &:hover {
       &::before {
@@ -353,9 +357,7 @@ input[type="radio"].cookieItemRadioBtn {
     right: 0;
   }
 
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
+  border-radius: 0;
 
   cursor: pointer;
   box-sizing: border-box;


### PR DESCRIPTION
1. Pressing tab key after Reset All button, focus will remain in Manage
2. Pressing shift + tab key after Manage cookie preferences dialog, focus will jump to Reset all button.