### PR TITLE
Fix the side of radio buttons in rtl

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -12,7 +12,8 @@
     <script src="consent-banner.js"></script>
     <script type="text/javascript">
         let options = { initialTheme: "light" };
-        let cc = new ConsentControl.ConsentControl("app", "en", (obj) => { console.log(obj); }, undefined, options);
+        let func = function(obj) { console.log(obj); };
+        let cc = new ConsentControl.ConsentControl("app", "en", func, undefined, options);
         cc.showBanner({});
     </script>
 </body>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -294,7 +294,7 @@ dt.cookieListItem {
   }
   padding: 3px;
 
-  @include rtlDesign(0 0 13px 34px, 0);
+  @include rtlDesign(0 0 13px 34px, 3px);
   @include rtlDesignPosition(auto, 5px);
 }
 
@@ -319,7 +319,7 @@ dt.cookieListItem {
     border: 1px solid $radio-button-border-color; 
     background-color: $dialog-background-color;
 
-    @include rtlDesignPosition(auto, 0);
+    @include rtlDesignPosition(auto, 3px);
   }
 
   &:not(:disabled) + label {
@@ -339,7 +339,7 @@ dt.cookieListItem {
         border-radius: 50%;
         background-color: $radio-button-hover-background-color;
 
-        @include rtlDesignPosition(auto, 5px);
+        @include rtlDesignPosition(auto, 8px);
       }
     }
 
@@ -359,7 +359,7 @@ dt.cookieListItem {
         border-radius: 50%;
         background-color: $radio-button-checked-background-color;
 
-        @include rtlDesignPosition(auto, 5px);
+        @include rtlDesignPosition(auto, 8px);
       }
     }
   }
@@ -375,7 +375,7 @@ dt.cookieListItem {
     border-radius: 50%;
     background-color: $radio-button-checked-background-color;
 
-    @include rtlDesignPosition(auto, 5px);
+    @include rtlDesignPosition(auto, 8px);
   }
 
   &:disabled + label {
@@ -397,6 +397,7 @@ input[type="radio"].cookieItemRadioBtn {
     right: 0;
   }
 
+  height: 0;
   width: 0;
   border-radius: 0;
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -39,6 +39,14 @@ $radio-button-disabled-border-color: rgba(0, 0, 0, 0.2);
   }
 }
 
+// For right-to-left direction (position)
+@mixin rtlDesignPosition($left, $right) {
+  div[dir="rtl"] & {
+    left: $left;
+    right: $right;
+  }
+}
+
 .bannerBody {
   position: relative;
   display: flex;
@@ -145,6 +153,7 @@ $radio-button-disabled-border-color: rgba(0, 0, 0, 0.2);
   @at-root div[dir="rtl"]#{ & } {
     text-align: right;
   }
+  @include rtlDesignPosition(auto, 0);
 }
 
 .modalContainer {
@@ -283,6 +292,9 @@ dt.cookieListItem {
     bottom: 16px;
     right: 34px;
   }
+
+  @include rtlDesign(0 0 16px 34px, 0);
+  @include rtlDesignPosition(auto, 5px);
 }
 
 .bannerBody *::before, .cookieModal *::before, .bannerBody *::after, .cookieModal *::after {
@@ -306,6 +318,8 @@ dt.cookieListItem {
     border-radius: 50%;
     border: 1px solid $radio-button-border-color; 
     background-color: $dialog-background-color;
+
+    @include rtlDesignPosition(auto, 0);
   }
 
   &:not(:disabled) + label {
@@ -324,6 +338,8 @@ dt.cookieListItem {
         content: "";
         border-radius: 50%;
         background-color: $radio-button-hover-background-color;
+
+        @include rtlDesignPosition(auto, 5px);
       }
     }
 
@@ -342,6 +358,8 @@ dt.cookieListItem {
         content: "";
         border-radius: 50%;
         background-color: $radio-button-checked-background-color;
+
+        @include rtlDesignPosition(auto, 5px);
       }
     }
   }
@@ -356,6 +374,8 @@ dt.cookieListItem {
     content: "";
     border-radius: 50%;
     background-color: $radio-button-checked-background-color;
+
+    @include rtlDesignPosition(auto, 5px);
   }
 
   &:disabled + label {
@@ -411,7 +431,7 @@ input[type="radio"].cookieItemRadioBtn {
   cursor: pointer;
   box-sizing: border-box;
 
-  @include rtlDesign(0 8px 0 34px, 0, left);
+  @include rtlDesign(0 19px 0 0, 0 8px 0 0, left);
 }
 
 .modalButtonGroup {
@@ -465,7 +485,7 @@ input[type="radio"].cookieItemRadioBtn {
     cursor: not-allowed;
   }
 
-  @include rtlDesign(0 10px 0 0, 0, left);
+  @include rtlDesign(0, 0, left);
 }
 
 @media only screen and (max-width: 800px) {
@@ -564,6 +584,6 @@ input[type="radio"].cookieItemRadioBtn {
     width: 100%;
     max-height: 28px;
 
-    @include rtlDesign(0 0 12px 0, 0);
+    @include rtlDesign(0 0 1% 0, 0);
   }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -273,7 +273,7 @@ dt.cookieListItem {
   display: inline-block;
   margin : {
     top: 0;
-    bottom: 16px;
+    bottom: 13px;
   }
 
   @include bannerFont(normal, 15px);
@@ -289,11 +289,12 @@ dt.cookieListItem {
   position: relative;
   left: 5px;
   margin : {
-    bottom: 16px;
+    bottom: 13px;
     right: 34px;
   }
+  padding: 3px;
 
-  @include rtlDesign(0 0 16px 34px, 0);
+  @include rtlDesign(0 0 13px 34px, 0);
   @include rtlDesignPosition(auto, 5px);
 }
 
@@ -303,15 +304,14 @@ dt.cookieListItem {
 
 .cookieItemRadioBtnCtrlOutline {
   outline: 2px solid $radio-button-hover-background-color;
-  outline-offset: 3px;
 }
 
 @mixin defineRaioInput {
   & + label::before {
     display: block;
     position: absolute;
-    top: 2px;
-    left: 0;
+    top: 5px;
+    left: 3px;
     height: 19px;
     width: 19px;
     content: "";
@@ -331,8 +331,8 @@ dt.cookieListItem {
       &::after {
         display: block;
         position: absolute;
-        top: 7px;
-        left: 5px;
+        top: 10px;
+        left: 8px;
         height: 9px;
         width: 9px;
         content: "";
@@ -351,8 +351,8 @@ dt.cookieListItem {
       &::after {
         display: block;
         position: absolute;
-        top: 7px;
-        left: 5px;
+        top: 10px;
+        left: 8px;
         height: 9px;
         width: 9px;
         content: "";
@@ -367,8 +367,8 @@ dt.cookieListItem {
   &:checked + label::after {
     display: block;
     position: absolute;
-    top: 7px;
-    left: 5px;
+    top: 10px;
+    left: 8px;
     height: 9px;
     width: 9px;
     content: "";


### PR DESCRIPTION
1. Fix the side of radio buttons in rtl
2. Since IE does not support `outline-offset`, remove it and use `padding`.