### PR TITLE
Set css `position` in label class to prevent using site css styles

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -413,12 +413,19 @@ input[type="radio"].cookieItemRadioBtn {
 
 .cookieItemRadioBtnLabel {
   display: block;
+  position: static;
   float: right;
   margin : {
+    top: 0;
+    bottom: 0;
     left: 19px;
+    right: 0;
   }
   padding : {
+    top: 0;
+    bottom: 0;
     left: 8px;
+    right: 0;
   }
   width: 80%;   /* If "calc()" is not supported */
 


### PR DESCRIPTION
1. Set `position: static` to prevent circle position using label
   position
2. Set `margin` and `padding` to prevent extra spaces