### PR TITLE
Add z-index to let X button stand out

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "consent-banner",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "The library which will generate a banner at the specified position for asking the cookie preferences.",
   "main": "dist/consent-banner.js",
   "types": "dist/consent-banner.d.ts",

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -174,6 +174,7 @@ $radio-button-disabled-border-color: rgba(0, 0, 0, 0.2);
 
 .closeModalIcon {
   float: right;
+  z-index: 1;
   margin: 2px;
   padding: 12px;
   border: none;
@@ -192,6 +193,7 @@ $radio-button-disabled-border-color: rgba(0, 0, 0, 0.2);
 }
 
 .modalBody {
+  position: static;
   margin : {
     top: 36px;
     left: 36px;


### PR DESCRIPTION
1. Set `position: static` in `modalBody`
2. Add `z-index` to `closeModalIcon` to prevent that 'X' is covered in the
   future.